### PR TITLE
add image batch generator

### DIFF
--- a/jim/workflow/step2-equirectangular-clipping/code/image_batch_generator.py
+++ b/jim/workflow/step2-equirectangular-clipping/code/image_batch_generator.py
@@ -166,9 +166,12 @@ def create_viewer(output_width, output_height, image_format):
         #     print_info(f"Key: [ - Previous image, Index: {current_image_index}")
         #     update_view()
         # elif key == ord(']'):  # ]キー
-            current_image_index = (current_image_index + 1) % len(image_files)
-            print_info(f"Key: ] - Next image, Index: {current_image_index}")
-            update_view()
+        current_image_index = (current_image_index + 1)
+        print_info(f"Key: ] - Next image, Index: {current_image_index}")
+        update_view()
+
+        if current_image_index == len(image_files) - 1:
+            break
         # elif key == ord('}'):  # Shift+]
         #     current_image_index = min(current_image_index + 10, len(image_files) - 1)
         #     print_info(f"Key: Shift+] - Forward 10 frames, Index: {current_image_index}")


### PR DESCRIPTION
複眼処理後の出力をウィンドウとして表示するのではなく指定されたディレクトリに連番画像として出力する機能を実装
- 出力パスはワーキングディレクトリ/output_{適用したフィルター名}/入力ファイル名_{適用したフィルタ名}.png
- パラメタ設定はpythonファイルを直接いじる必要有り, 最終的には設定ファイルを読み取る形へ修正する予定