### PR TITLE
マッハバンド対策としてガウシアンフィルタへ変更

### DIFF
--- a/workspace/step2-equirectangular-clipping/code/hexagonal_filter.py
+++ b/workspace/step2-equirectangular-clipping/code/hexagonal_filter.py
@@ -156,5 +156,6 @@ def apply_uniform_blur(image, blur_size):
     if blur_size % 2 == 0:
         blur_size += 1
     
-    kernel = np.ones((blur_size, blur_size), np.float32) / (blur_size * blur_size)
-    return cv2.filter2D(image, -1, kernel)
+    # kernel = np.ones((blur_size, blur_size), np.float32) / (blur_size * blur_size)
+    #return cv2.filter2D(image, -1, kernel)
+    return cv2.GaussianBlur(image, (blur_size, blur_size), 0)

--- a/workspace/step2-equirectangular-clipping/code/viewer.py
+++ b/workspace/step2-equirectangular-clipping/code/viewer.py
@@ -39,7 +39,7 @@ def create_viewer(output_width, output_height, image_format):
         'filter': 'hexagonal_depth_gaussian',  # フィルタの初期設定
         'view_mode': 'color',  # 表示モードの初期設定
         'debug_mode': False,  # デバッグモードの初期設定
-        'blur_size': 30  # ブラーサイズの初期値
+        'blur_size': 60  # ブラーサイズの初期値
     }
 
     cv2.namedWindow('360 Viewer', cv2.WINDOW_NORMAL)


### PR DESCRIPTION
- 白黒の市松画像で確認した結果, Box フィルターを適用すると同様のアーティファクトが現れることを確認
- Boxフィルタ―が画素の不連続変化に対して線形な補間を行うことに原因があると想定
- Gaussainフィルターに変更したところ, アーティファクトがほぼ見られないことを確認
- 実際の六角描画に適用しても同様の傾向がみられた